### PR TITLE
Quiz solution

### DIFF
--- a/Document.php
+++ b/Document.php
@@ -1,49 +1,65 @@
 <?php
 class Document {
 
-    public $user;
+    const CONTENT_COL = 6;
+    const TITLE_COL = 3;
 
-    public $name;
+    private $user;
 
-    public function init($name, User $user) {
+    private $name;
+
+    public function __construct($name, User $user) {
         assert(strlen($name) > 5);
         $this->user = $user;
         $this->name = $name;
     }
 
+    public function get_user(){
+
+        return $this->user;
+    }
+
+    public function get_name(){
+
+        $this->name;
+    }
+
     public function getTitle() {
-        $db = Database::getInstance();
-        $row = $db->query('SELECT * FROM document WHERE name = "' . $this->name . '" LIMIT 1');
-        return $row[3]; // third column in a row
+
+        return $this->get_attribute(self::TITLE_COL); // third column in a row
     }
 
     public function getContent() {
-        $db = Database::getInstance();
-        $row = $db->query('SELECT * FROM document WHERE name = "' . $this->name . '" LIMIT 1');
-        return $row[6]; // sixth column in a row
+
+        return $this->get_attribute(self::CONTENT_COL);
     }
 
     public static function getAllDocuments() {
         // to be implemented later
     }
 
+    private function get_attribute($column_number){
+        $db = Database::getInstance();
+        $row = $db->query('SELECT * FROM document WHERE name = "' . $this->name . '" LIMIT 1');
+        return $row[$column_number]; // third column in a row
+    }
 }
 
 class User {
 
     public function makeNewDocument($name) {
-        $doc = new Document();
-        $doc->init($name, $this);
+        $doc = new Document($name, $this);
+
         return $doc;
     }
 
     public function getMyDocuments() {
         $list = array();
-        foreach (Document::getAllDocuments() as $doc) {
-            if ($doc->user == $this)
+        $all_docs = Document::getAllDocuments();
+        foreach ($all_docs as $doc) {
+            if ($doc->get_user() == $this)
                 $list[] = $doc;
         }
         return $list;
     }
-
 }


### PR DESCRIPTION
* Removed public property access to $user and $name.
 ** Added getters for those
* Removed magic numbers for the column indexes
* Removed duplication in the database interaction.
* Renamed init() method into the constructor that it is suggested to be by the "make" in makeNewDocument and it being called after the empty constructor.

Further steps:
* Database interaction should be improved "SELECT * " could probably be turned into "SELECT title,name" or some access by column number depending on the DB server.
** only need one SQL call for both values by saving them somewhere
** remove the singleton on the getInstance for the Database, use proper dependency injection
* Refactor the constructor use in makeNewDocument into some proper factory use for testability
* Same goes for turning the \Document::getAllDocuments into something non-static that can be mocked properly

