### PR TITLE
Refactored Parser.java

### DIFF
--- a/Parser.java
+++ b/Parser.java
@@ -28,7 +28,7 @@ public class Parser {
     try {
       StringBuilder output = new StringBuilder();
       int data;
-      while ((data = i.read()) > 0) {
+      while ((data = i.read()) != -1) {
         if (withUnicode || data < 0x80) {
           output.append((char) data);
         }

--- a/Parser.java
+++ b/Parser.java
@@ -1,42 +1,51 @@
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
+
 /**
  * This class is thread safe.
  */
 public class Parser {
-  private File file;
-  public synchronized void setFile(File f) {
-    file = f;
+
+  private final File file;
+
+  public Parser(File file) {
+  	this.file = file;
   }
-  public synchronized File getFile() {
+  
+  public File getFile() {
     return file;
   }
+
   public String getContent() throws IOException {
-    FileInputStream i = new FileInputStream(file);
-    String output = "";
-    int data;
-    while ((data = i.read()) > 0) {
-      output += (char) data;
-    }
-    return output;
+    return getContent(true);
   }
+
   public String getContentWithoutUnicode() throws IOException {
-    FileInputStream i = new FileInputStream(file);
-    String output = "";
-    int data;
-    while ((data = i.read()) > 0) {
-      if (data < 0x80) {
-        output += (char) data;
-      }
-    }
-    return output;
+    return getContent(false);
   }
+
+  protected String getContent(boolean withUnicode) throws IOException {
+    BufferedInputStream i = new BufferedInputStream(new FileInputStream(file));
+    try {
+      StringBuilder output = new StringBuilder();
+      int data;
+      while ((data = i.read()) > 0) {
+        if (withUnicode || data < 0x80) {
+          output.append((char) data);
+        }
+      }
+      return output.toString();
+    } finally {
+      i.close();
+    }
+  }
+
+
   public void saveContent(String content) throws IOException {
-    FileOutputStream o = new FileOutputStream(file);
-    for (int i = 0; i < content.length(); i += 1) {
-      o.write(content.charAt(i));
+    BufferedOutputStream o = new BufferedOutputStream(new FileOutputStream(file));
+    try {
+      o.write(content.getBytes());
+    } finally {
+      o.close();
     }
   }
 }


### PR DESCRIPTION
As instructed a simple refactoring of the Parser.java class.

  * Wrapped FileInputStreams in BufferedInputStream and BufferedOutputStream for improved speed
  * Made the Parser.java class immutable by having the "file" field final and set at construction instead of using a setter. Note that this change breaks the API, but is a small change and easily caught by the compiler.
  * Removed duplication in getContents* methods. Used overloading to ensure the API does not change.
  * Closed the streams. Necessary so we don't run out of file descriptors and ensure the output gets written. Wrapped in a try/finally block to ensure this always happens.
  * Fixed the "`(data = i.read()) > 0`" check. This would ignore the valid null-byte character (`\0`)
  * Used StringBuilder instead of String concatenation for better performance.