### PR TITLE
Parser (java) refactor

### DIFF
--- a/Parser.java
+++ b/Parser.java
@@ -2,41 +2,63 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.MappedByteBuffer;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.Files;
+import java.nio.channels.FileChannel;
+
 /**
  * This class is thread safe.
  */
 public class Parser {
-  private File file;
-  public synchronized void setFile(File f) {
-    file = f;
+
+  /*
+   * Using volatile implies cpu-level memory barriers. This ensures
+   * that all _active_ calls to read/write methods (i.e. getContent)
+   * operate on the file that was previously set, while all _future_
+   * calls to the methods operate on the new file.
+   */
+  private volatile File file;
+
+  public Parser() {
   }
-  public synchronized File getFile() {
-    return file;
+
+  public void setFile(File f) {
+    this.file = f;
   }
+
+  public File getFile() {
+    return this.file;
+  }
+
   public String getContent() throws IOException {
-    FileInputStream i = new FileInputStream(file);
-    String output = "";
-    int data;
-    while ((data = i.read()) > 0) {
-      output += (char) data;
-    }
-    return output;
+    return new String(Files.readAllBytes(file.toPath()));
   }
+
   public String getContentWithoutUnicode() throws IOException {
-    FileInputStream i = new FileInputStream(file);
-    String output = "";
-    int data;
-    while ((data = i.read()) > 0) {
-      if (data < 0x80) {
-        output += (char) data;
+    /*
+     * Depending on how large the file is, mapping it
+     * might not be plausible (however, since we're stuffing
+     * a the read data into a string builder, I don't imagine
+     * it'd be that big anyway.)
+     */
+    MappedByteBuffer mmap;
+    StringBuilder res = new StringBuilder();
+
+    try (FileChannel fc = FileChannel.open(file.toPath(),
+                                           StandardOpenOption.READ)) {
+      mmap = fc.map(FileChannel.MapMode.READ_ONLY, 0, fc.size());
+      while (mmap.hasRemaining()) {
+      	int c = mmap.get() & 0xff;
+      	if (c < 0x80)
+      	  res.append((char) c);
       }
     }
-    return output;
+    return res.toString();
   }
+
   public void saveContent(String content) throws IOException {
-    FileOutputStream o = new FileOutputStream(file);
-    for (int i = 0; i < content.length(); i += 1) {
-      o.write(content.charAt(i));
-    }
+    Files.write(file.toPath(), content.getBytes());
   }
 }


### PR DESCRIPTION
I used the new Files.<foo> api to perform the simple read/write operations. For the more involved read without unicode operation, I map the file into memory and iterate through it. Since the read result was being returned in the string, I don't imagine this would incur any hefty memory restrictions. I also switched the getter/setter for the file variable to non-synchronized, and instead marked the file field volatile to ensure future calls to any of the op methods use the newly updated value.