### PR TITLE
Parser fearless refactoring

### DIFF
--- a/Parser.java
+++ b/Parser.java
@@ -2,41 +2,33 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 /**
  * This class is thread safe.
  */
 public class Parser {
-  private File file;
-  public synchronized void setFile(File f) {
-    file = f;
+  private static final Charset CHARSET = StandardCharsets.UTF_8;
+  private static final Pattern REGEX_NON_ASCII = Pattern.compile("[^\\x00-\\x7F]");
+  private final File file;
+
+  public Parser(File file) {
+    this.file = file;
   }
-  public synchronized File getFile() {
-    return file;
-  }
+
   public String getContent() throws IOException {
-    FileInputStream i = new FileInputStream(file);
-    String output = "";
-    int data;
-    while ((data = i.read()) > 0) {
-      output += (char) data;
-    }
-    return output;
+    return new String(Files.readAllBytes(file.toPath()), CHARSET);
   }
+
   public String getContentWithoutUnicode() throws IOException {
-    FileInputStream i = new FileInputStream(file);
-    String output = "";
-    int data;
-    while ((data = i.read()) > 0) {
-      if (data < 0x80) {
-        output += (char) data;
-      }
-    }
-    return output;
+    return REGEX_NON_ASCII.matcher(getContent()).replaceAll("");
   }
   public void saveContent(String content) throws IOException {
-    FileOutputStream o = new FileOutputStream(file);
-    for (int i = 0; i < content.length(); i += 1) {
-      o.write(content.charAt(i));
-    }
+    Files.write(file.toPath(), content.getBytes(CHARSET));
   }
 }


### PR DESCRIPTION
I am sure that all the fuss about synchronization in this case (of course I looked through the latest 10 PR) is fundamentally wrong &mdash; `synchronized`, `volatile` and especially `ReadWriteLock` are overkill. This class must be immutable. There is no sense in creating one instance of `Parser` and setting another file to it. Creating a new object is cheap, synchronization is expensive.
Locking on file itself is done by OS, so there is no sense in synchronizing reading and writing of any content as well.

Almost everybody tries to make `readContent` and `saveContent` more elegant or short, but keeps silent that their modifications change the behaviour of these methods: 
- `saveContent` passes char (2 bytes) to method writing byte, thus its every non-ASCII byte is truncated;
- `getContent` reads byte and cast it to char, what is wrong if 2 or 3 bytes char is written to file.<br>It's not clear if it is intentional behaviour, but looks like bugs and it is not working as expected
  (although it is not clear how it is expected) with unicode strings.

If we assume that we need to skip all two and three bytes characters in method `getContentWithoutUnicode` then we do it as well wrong:

> - With the high bit set to 0, it's a single byte value.
> - With the two high bits set to 10, it's a continuation byte.
> - Otherwise, it's the first byte of a multi-byte sequence and the number of leading 1 bits indicates how many bytes there are in total for this sequence (110... means two bytes, 1110... means three bytes, etc).
>   &mdash; <cite>[stackoverflow.com](http://stackoverflow.com/a/3911566/4932896)</cite>

In initial code we skip only continuation bytes and add to the result string all other bytes left from the character. We can replace `String` with `StringBuffer` to make it either "more elegant" or "faster" (I doubt by the way) - some PR contains such refactoring, but it hardly helps.
I was going to simply iterate and filter the character array, but I liked the @exper0 solution from one of the last PR which uses regexp.

Java 1.7 was released more than 3 years ago, but there are only few attempts to use its helpers methods as well as the new syntax for `try` clause.

I would rename the class to something like `FileContentAccessor`, because it doesn't parse anything and both reads and writes a file.
