### PR TITLE
corrected version

### DIFF
--- a/Parser.java
+++ b/Parser.java
@@ -2,41 +2,60 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+
+
 /**
  * This class is thread safe.
  */
 public class Parser {
-  private File file;
-  public synchronized void setFile(File f) {
-    file = f;
-  }
-  public synchronized File getFile() {
-    return file;
-  }
-  public String getContent() throws IOException {
-    FileInputStream i = new FileInputStream(file);
-    String output = "";
-    int data;
-    while ((data = i.read()) > 0) {
-      output += (char) data;
+
+    private final File file;
+
+    public Parser(File file) throws IOException {
+        //TODO: maybe add some null-check
+        this.file = file;
+        if (!file.exists()) {       // or any other approach, e.g throwing exception if not exists
+            file.createNewFile();
+        }
     }
-    return output;
-  }
-  public String getContentWithoutUnicode() throws IOException {
-    FileInputStream i = new FileInputStream(file);
-    String output = "";
-    int data;
-    while ((data = i.read()) > 0) {
-      if (data < 0x80) {
-        output += (char) data;
-      }
+
+    public String getContent() throws IOException {
+        return getContentWithUnicode(true);
     }
-    return output;
-  }
-  public void saveContent(String content) throws IOException {
-    FileOutputStream o = new FileOutputStream(file);
-    for (int i = 0; i < content.length(); i += 1) {
-      o.write(content.charAt(i));
+
+    public String getContentWithoutUnicode() throws IOException {
+        return getContentWithUnicode(false);
     }
-  }
+
+    private String getContentWithUnicode(boolean withUnicode) throws IOException {
+        FileInputStream i = new FileInputStream(file);
+        StringBuilder sb = new StringBuilder();
+        int data;
+        synchronized (this) {       // to avoid dirty-read
+            while ((data = i.read()) > 0) {
+                if (withUnicode) {
+                    sb.append((char) data);
+                } else {
+                    if (data < 0x80) {
+                        sb.append((char) data);
+                    }
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    public void saveContent(String content) throws IOException {
+        if (content == null) {
+            return;     // or exception, or build empty string to clear content of the file
+        }
+        synchronized (this) {   // only one thread writes to the file at the moment
+            try (FileOutputStream o = new FileOutputStream(file)) {     // maybe the use of BufferedOutputStream would be more desirable
+                o.write(content.getBytes());
+                o.flush();
+            } catch (IOException e) {
+                throw e;    // or other handling
+            }
+        }
+    }
 }


### PR DESCRIPTION
Done:
- better approach with parameterized constructor instead of getter/setter
- single (final) File per Parser instance 
- StringBuilder instead of (many) String concatenation
- synchronized blocks for better thread-safe
- try-with-resources statement for auto releasing resources (closeable)

TODO:
- more null checks if needed
- consider buffered method for OutputStreams
- maybe StringBuffer instead of synchronized block
 