### PR TITLE
fixes in the Parser class

### DIFF
--- a/Parser.java
+++ b/Parser.java
@@ -7,6 +7,24 @@ import java.io.IOException;
  */
 public class Parser {
   private File file;
+  private static final int HEX_80 = 0x80;
+
+  /**
+   * Constructor which supplies the file to the Parser object.
+   * @param file - the file that this Parser works with.
+   */
+  public Parser(File file) {
+	this.file = file;
+  }
+
+  /**
+   * Constructor which looks for the file at the specified path.
+   * @param filePath - the path to the file that this Parser works with.
+   */
+  public Parser(String filePath) {
+	this.file = new File(filePath);
+  }
+  
   public synchronized void setFile(File f) {
     file = f;
   }
@@ -14,29 +32,34 @@ public class Parser {
     return file;
   }
   public String getContent() throws IOException {
-    FileInputStream i = new FileInputStream(file);
-    String output = "";
+    FileInputStream inputStream = new FileInputStream(file);
+    StringBuilder output = new StringBuilder();
     int data;
-    while ((data = i.read()) > 0) {
-      output += (char) data;
+    while ((data = inputStream.read()) > 0) {
+      output.append((char) data);
     }
-    return output;
+    
+    inputStream.close();
+    return output.toString();
   }
   public String getContentWithoutUnicode() throws IOException {
-    FileInputStream i = new FileInputStream(file);
-    String output = "";
+    FileInputStream inputStream = new FileInputStream(file);
+    StringBuilder output = new StringBuilder();
     int data;
-    while ((data = i.read()) > 0) {
-      if (data < 0x80) {
-        output += (char) data;
+    while ((data = inputStream.read()) > 0) {
+      if (data < HEX_80) {
+        output.append((char) data);
       }
     }
-    return output;
+    inputStream.close();
+
+    return output.toString();
   }
-  public void saveContent(String content) throws IOException {
-    FileOutputStream o = new FileOutputStream(file);
-    for (int i = 0; i < content.length(); i += 1) {
-      o.write(content.charAt(i));
+  public synchronized void saveContent(String content) throws IOException {
+    FileOutputStream outputStream = new FileOutputStream(file);
+    for (int i = 0; i < content.length(); i++) {
+      outputStream.write(content.charAt(i));
     }
+    outputStream.close();
   }
 }


### PR DESCRIPTION
1) added constructors. Using the implicit constructor can cause NPE if the setter isn't called before doing anything else. 
2) made the saveContent method synchronized
3) closed inputStreams
4) variables renaming and little syntax changes. e.g. i++ instead i+=1. 
5) pulled out 0x80 literal into constant class variable. 
6) using StringBuilder instead string concatenation. 