### PR TITLE
Quiz - Refactor Parse.java

### DIFF
--- a/Parser.java
+++ b/Parser.java
@@ -1,42 +1,53 @@
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+
 /**
  * This class is thread safe.
  */
 public class Parser {
-  private File file;
-  public synchronized void setFile(File f) {
-    file = f;
-  }
-  public synchronized File getFile() {
-    return file;
-  }
-  public String getContent() throws IOException {
-    FileInputStream i = new FileInputStream(file);
-    String output = "";
-    int data;
-    while ((data = i.read()) > 0) {
-      output += (char) data;
+
+    private File file;
+
+    public synchronized void setFile(File f) {
+        file = f;
     }
-    return output;
-  }
-  public String getContentWithoutUnicode() throws IOException {
-    FileInputStream i = new FileInputStream(file);
-    String output = "";
-    int data;
-    while ((data = i.read()) > 0) {
-      if (data < 0x80) {
-        output += (char) data;
-      }
+
+    public synchronized File getFile() {
+        return file;
     }
-    return output;
-  }
-  public void saveContent(String content) throws IOException {
-    FileOutputStream o = new FileOutputStream(file);
-    for (int i = 0; i < content.length(); i += 1) {
-      o.write(content.charAt(i));
+
+    public synchronized String getContent(boolean isUnicode) throws IOException {
+
+        try (BufferedReader br =
+                     new BufferedReader(
+                             new InputStreamReader(
+                                     new FileInputStream(file), StandardCharsets.UTF_8))) {
+            StringBuilder sb = new StringBuilder();
+            int data;
+            while ((data = br.read()) != -1) {
+                if (isUnicode) {
+                    sb.append((char) data);
+                } else if (data < 0x80) {
+                    sb.append((char) data);
+                }
+            }
+            return sb.toString();
+        }
     }
-  }
+
+    public synchronized void saveContent(String content) throws IOException {
+        try (OutputStreamWriter o =
+                     new OutputStreamWriter(
+                             new FileOutputStream(file), StandardCharsets.UTF_8)) {
+            for (int i = 0; i < content.length(); i += 1) {
+                o.write(content.charAt(i));
+            }
+        }
+    }
 }


### PR DESCRIPTION
Remove duplicate methods 'getContent()' and 'getContentWithoutUnicode()' and
use a single method 'getContent(boolean isUnicode)' instead.

Use of the StringBuilder instead string concatenation to achieve better performance.

Use of the Java 7 try-with-resources to achieve correct closing of the streams.

Rework creation of the streams to achieve proper reading/writing of the Unicode
characters like Cyrillic or Hebrew from/to the file.