### PR TITLE
quiz answer

### DIFF
--- a/Parser.java
+++ b/Parser.java
@@ -1,42 +1,42 @@
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
+
 /**
  * This class is thread safe.
  */
 public class Parser {
-  private File file;
-  public synchronized void setFile(File f) {
-    file = f;
-  }
-  public synchronized File getFile() {
-    return file;
-  }
-  public String getContent() throws IOException {
-    FileInputStream i = new FileInputStream(file);
-    String output = "";
-    int data;
-    while ((data = i.read()) > 0) {
-      output += (char) data;
+
+    public  String getContent(File input, boolean unicode) throws IOException {
+
+        String output = "";
+        FileInputStream i = null;
+
+        try {
+            i = new FileInputStream(input);
+            int data;
+            while ((data = i.read()) > 0) {
+
+                if (!unicode || (data < 0x80)) {
+                    output += (char) data;
+                }
+            }
+        } finally {
+            i.close();
+        }
+
+        return output;
     }
-    return output;
-  }
-  public String getContentWithoutUnicode() throws IOException {
-    FileInputStream i = new FileInputStream(file);
-    String output = "";
-    int data;
-    while ((data = i.read()) > 0) {
-      if (data < 0x80) {
-        output += (char) data;
-      }
+
+    public  void saveContent(String content, File output) throws IOException {
+        FileOutputStream o = null;
+
+        try {
+            o = new FileOutputStream(output);
+
+            for (int i = 0; i < content.length(); i ++) {
+                o.write(content.charAt(i));
+            }
+        } finally {
+            o.close();
+        }
     }
-    return output;
-  }
-  public void saveContent(String content) throws IOException {
-    FileOutputStream o = new FileOutputStream(file);
-    for (int i = 0; i < content.length(); i += 1) {
-      o.write(content.charAt(i));
-    }
-  }
 }


### PR DESCRIPTION
- I tidied up the unneeded member variable, which eliminated the need for synchronized specifiers
- These operations are probably best done atomically, so that's how I set it up, though it is a bit more functional than OO
- Next steps (take longer than 15 min):
   - Put the threading inside the two operations, and add a listener interface which gets called on the original thread when complete.  The listener would be added at the same time the function is called, and could be a one-off.  Alternatively, a Listener list could be keep with a synchronized approach.
   - This will also involve catching the IOException and passing that error information back to the original thread
   - With these changes the operations could be called from any thread, and results read when they are ready, without holding up the show on the original thread.  I have done things similar to this quite a bit on Android and iOS, where you never do io operations on the main thread.