### PR TITLE
Update Parser.java

### DIFF
--- a/Parser.java
+++ b/Parser.java
@@ -39,7 +39,7 @@ public class Parser {
   }
   public synchronized void saveContent(String content) throws IOException {
     try(FileOutputStream outputStream = new FileOutputStream(file)){
-    o.write(content.getBytes());
+    outputStream.write(content.getBytes());
     }
   }
 }

--- a/Parser.java
+++ b/Parser.java
@@ -15,11 +15,11 @@ public class Parser {
   }
   public synchronized String getContent() throws IOException {
     try(
-    FileInputStream i = new FileInputStream(file)){
-    StringBuilder output = null;
+    FileInputStream inputStream = new FileInputStream(file)){
+    StringBuilder output = new StringBuilder();
     int data;
     byte[] buffer = new byte[1024];
-    while ((data = i.read(buffer)) != -1) {
+    while ((data = inputStream.read(buffer)) != -1) {
       output.append(new String(buffer, 0, data).toCharArray());
     }
     return output.toString();
@@ -27,11 +27,11 @@ public class Parser {
   }
   public synchronized String getContentWithoutUnicode() throws IOException {
    try(
-    FileInputStream i = new FileInputStream(file)){
-    StringBuilder output = null;
+    FileInputStream inputStream = new FileInputStream(file)){
+    StringBuilder output = StringBuilder();
     int data;
     byte[] buffer = new byte[1024];
-    while ((data = i.read(buffer)) != -1) {
+    while ((data = inputStream.read(buffer)) != -1) {
       output.append(new String(buffer, 0, data).toCharArray());
     }
     return output.toString();

--- a/Parser.java
+++ b/Parser.java
@@ -13,30 +13,33 @@ public class Parser {
   public synchronized File getFile() {
     return file;
   }
-  public String getContent() throws IOException {
-    FileInputStream i = new FileInputStream(file);
-    String output = "";
+  public synchronized String getContent() throws IOException {
+    try(
+    FileInputStream i = new FileInputStream(file)){
+    StringBuilder output = null;
     int data;
-    while ((data = i.read()) > 0) {
-      output += (char) data;
+    byte[] buffer = new byte[1024];
+    while ((data = i.read(buffer)) != -1) {
+      output.append(new String(buffer, 0, data).toCharArray());
     }
-    return output;
+    return output.toString();
+    }
   }
-  public String getContentWithoutUnicode() throws IOException {
-    FileInputStream i = new FileInputStream(file);
-    String output = "";
+  public synchronized String getContentWithoutUnicode() throws IOException {
+   try(
+    FileInputStream i = new FileInputStream(file)){
+    StringBuilder output = null;
     int data;
-    while ((data = i.read()) > 0) {
-      if (data < 0x80) {
-        output += (char) data;
-      }
+    byte[] buffer = new byte[1024];
+    while ((data = i.read(buffer)) != -1) {
+      output.append(new String(buffer, 0, data).toCharArray());
     }
-    return output;
+    return output.toString();
+    }
   }
-  public void saveContent(String content) throws IOException {
-    FileOutputStream o = new FileOutputStream(file);
-    for (int i = 0; i < content.length(); i += 1) {
-      o.write(content.charAt(i));
+  public synchronized void saveContent(String content) throws IOException {
+    try(FileOutputStream o = new FileOutputStream(file)){
+    o.write(content.getBytes());
     }
   }
 }

--- a/Parser.java
+++ b/Parser.java
@@ -16,29 +16,29 @@ public class Parser {
   public synchronized String getContent() throws IOException {
     try(
     FileInputStream inputStream = new FileInputStream(file)){
-    StringBuilder output = new StringBuilder();
+    StringBuilder outputBuilder = new StringBuilder();
     int data;
     byte[] buffer = new byte[1024];
     while ((data = inputStream.read(buffer)) != -1) {
-      output.append(new String(buffer, 0, data).toCharArray());
+      outputBuilder.append(new String(buffer, 0, data).toCharArray());
     }
-    return output.toString();
+    return outputBuilder.toString();
     }
   }
   public synchronized String getContentWithoutUnicode() throws IOException {
    try(
     FileInputStream inputStream = new FileInputStream(file)){
-    StringBuilder output = StringBuilder();
+    StringBuilder outputBuilder = StringBuilder();
     int data;
     byte[] buffer = new byte[1024];
     while ((data = inputStream.read(buffer)) != -1) {
-      output.append(new String(buffer, 0, data).toCharArray());
+      outputBuilder.append(new String(buffer, 0, data).toCharArray());
     }
     return output.toString();
     }
   }
   public synchronized void saveContent(String content) throws IOException {
-    try(FileOutputStream o = new FileOutputStream(file)){
+    try(FileOutputStream outputStream = new FileOutputStream(file)){
     o.write(content.getBytes());
     }
   }


### PR DESCRIPTION
#FileInputStream and FileOutputStream are implemented java.io.AutoCloseable we can use try with resources statement no explicit stream closes needed.
Class must be Thread safe.
while reading single byte each time causes more os calls so read(byte[]) byte is used to reduce os calls.
while writing each byte also causes more os calls, write(byte[]) is used.
instead of String StringBuilder is used because String is immutable so any operations performed on String causes more objects to be created, so StringBuilder is used for mutable behavior.
and java naming stands should be followed for clear understanding of code.
Example: instead i for FileInputStream inputStream is used.