### PR TITLE
use stringbuilder instead of string class for string concatenation in loop

### DIFF
--- a/Parser.java
+++ b/Parser.java
@@ -24,14 +24,14 @@ public class Parser {
   }
   public String getContentWithoutUnicode() throws IOException {
     FileInputStream i = new FileInputStream(file);
-    String output = "";
+    StringBuilder output = new StringBuilder();
     int data;
     while ((data = i.read()) > 0) {
       if (data < 0x80) {
-        output += (char) data;
+        output.append((char) data);
       }
     }
-    return output;
+    return output.toString();
   }
   public void saveContent(String content) throws IOException {
     FileOutputStream o = new FileOutputStream(file);


### PR DESCRIPTION
It is better to use single StringBuilder object to concatenate characters instead of recreation string object on every cycle.