### PR TITLE
Refactor so that there is no interdepency between `User` and `Document`

### DIFF
--- a/Document.php
+++ b/Document.php
@@ -1,49 +1,89 @@
 <?php
-class Document {
 
+/**
+ * Intentionally lightweight.
+ *
+ * TODO There should at least by an `id` property here. So that {@link Document} can properly reference self. That
+ *      property can be used for easy queries.
+ */
+class User {
+
+}
+
+class Document {
+    /**
+     * @var User
+     */
     public $user;
 
+    /**
+     * @var string
+     */
     public $name;
+    /**
+     * @var string
+     */
+    public $title;
+    /**
+     * @var string
+     */
+    public $content;
 
-    public function init($name, User $user) {
+    public function __construct($name, User $user = null) {
+        // TODO Should throw an Exception instead especially if the $name comes from a user input.
+
         assert(strlen($name) > 5);
         $this->user = $user;
         $this->name = $name;
     }
 
-    public function getTitle() {
+    /**
+     * @return Document[]
+     */
+    public static function findAll() {
+        // TODO to be implemented later
+        return [];
+    }
+
+    /**
+     * @param string $name
+     * @return Document
+     */
+    public static function findByName($name) {
         $db = Database::getInstance();
-        $row = $db->query('SELECT * FROM document WHERE name = "' . $this->name . '" LIMIT 1');
-        return $row[3]; // third column in a row
-    }
+        $row = $db->query('SELECT * FROM document WHERE name = "' . mysql_real_escape_string($name) . '" LIMIT 1');
 
-    public function getContent() {
-        $db = Database::getInstance();
-        $row = $db->query('SELECT * FROM document WHERE name = "' . $this->name . '" LIMIT 1');
-        return $row[6]; // sixth column in a row
-    }
+        if (!$row) {
+            return null;
+        }
 
-    public static function getAllDocuments() {
-        // to be implemented later
-    }
+        $doc = new Document($name);
+        $doc->title = $row[3];
+        $doc->content = $row[6];
 
-}
+        // TODO Set $doc->user as well
 
-class User {
-
-    public function makeNewDocument($name) {
-        $doc = new Document();
-        $doc->init($name, $this);
         return $doc;
     }
 
-    public function getMyDocuments() {
-        $list = array();
-        foreach (Document::getAllDocuments() as $doc) {
-            if ($doc->user == $this)
+    /**
+     * @param User $user
+     * @return Document[]
+     */
+    public static function findAllForUser(User $user) {
+        // TODO This needs to be changed into an actual query. Unfortunately, there is no defined way of how
+        // `Document` references `User`.
+
+        $list = [];
+        foreach (self::findAll() as $doc) {
+            // TODO this comparison may not be enough. Perhaps a `user->id` comparison would be more efficient and will
+            // not provide false negatives.
+            if ($doc->user == $user) {
                 $list[] = $doc;
+            }
         }
         return $list;
     }
-
 }
+
+


### PR DESCRIPTION
## Assumptions

Given that there's no definition on what the classes are supposed to achive, I have made these assumptions when deciding how to refactor them:
- The classes are ORM classes
- There are three expected functionalities that can be achieved with the classes:
  - Creating a new document which has a `name`, `title`, and `content`
  - Getting all the documents
  - Getting all the documents created by a user
- The `title` and `content` properties of `Document` are lightweight strings and are not huge binaries
## Refactor
- Got rid of the interdependence between `User` and `Document` by moving all query functions into `Document`. This results in a lightweight `User` class that is not dependent on `Document`. `Document` is still dependent on `User` and is the only entry point for querying `Document` objects from the database.
- Removed the unnecessary queries for getting the values of `title` and `content`. They are instead loaded whenever a full `Document` object is loaded and are stored in their corresponding properties.
- Prevented a possible SQL injection attack in `findByName` by using `mysql_real_escape_string`. Given that I have no idea what the `Database` class contains, I used that deprecated function as a temporary solution.
- Used a proper PHP constructor for `Document`.
## Future Improvements
- To solve the testability issue of the static functions, the `Database` can be changed into a service in a service locator where it would be possible to swap or mock. This can allow us to have consistent return values from the query functions.
- The usage of `mysql_real_escape_string` needs to be changed into something that is not deprecated. Something like a `PDO->bindParam` would be better.
- There is no real defined way of how `Document` references `User`, there should at least be a `User->id` property and then `Document` can have a `Document->userId` property. This can allow us to do a better query in `findAllForUser`. The `Document->user` can still be included in the queries if needed (using SQL joins and such).
- The `Document` constructor should throw an `Exception` instead of just an `assert` if `$name` can come from a user input. A validator would also be beneficial before actually saving the object in the database.
- The `Document::findAllForUser()` should do an actual database query which would generally be faster.
## Others

The refactor took 21 mins. More than half of the time was spent on trying to understand the problem and identifying assumptions. Writing this commit message was not included in the timer.
